### PR TITLE
Fixing broken build: Entities\TransactionStatus.cs was missing from t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 # User-specific files
 *.suo
 *.user
+*.userosscache
 *.sln.docstates
+*.Development.json
 
 # Build results
 
@@ -14,6 +16,9 @@ x64/
 build/
 [Bb]in/
 [Oo]bj/
+
+# Visual Studio 2015 cache/options directory
+.vs/
 
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/
@@ -154,3 +159,19 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+/packages/Newtonsoft.Json.5.0.8/tools/install.ps1
+/packages/Newtonsoft.Json.5.0.8/Newtonsoft.Json.5.0.8.nupkg
+/packages/Newtonsoft.Json.5.0.8/lib/portable-net45+wp80+win8/Newtonsoft.Json.xml
+/packages/Newtonsoft.Json.5.0.8/lib/portable-net45+wp80+win8/Newtonsoft.Json.dll
+/packages/Newtonsoft.Json.5.0.8/lib/portable-net40+sl4+wp7+win8/Newtonsoft.Json.xml
+/packages/Newtonsoft.Json.5.0.8/lib/portable-net40+sl4+wp7+win8/Newtonsoft.Json.dll
+/packages/Newtonsoft.Json.5.0.8/lib/netcore45/Newtonsoft.Json.xml
+/packages/Newtonsoft.Json.5.0.8/lib/netcore45/Newtonsoft.Json.dll
+/packages/Newtonsoft.Json.5.0.8/lib/net45/Newtonsoft.Json.xml
+/packages/Newtonsoft.Json.5.0.8/lib/net45/Newtonsoft.Json.dll
+/packages/Newtonsoft.Json.5.0.8/lib/net40/Newtonsoft.Json.xml
+/packages/Newtonsoft.Json.5.0.8/lib/net40/Newtonsoft.Json.dll
+/packages/Newtonsoft.Json.5.0.8/lib/net35/Newtonsoft.Json.xml
+/packages/Newtonsoft.Json.5.0.8/lib/net35/Newtonsoft.Json.dll
+/packages/Newtonsoft.Json.5.0.8/lib/net20/Newtonsoft.Json.xml
+/packages/Newtonsoft.Json.5.0.8/lib/net20/Newtonsoft.Json.dll

--- a/Openpay/Openpay.csproj
+++ b/Openpay/Openpay.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Entities\Merchant.cs" />
+    <Compile Include="Entities\TransactionStatus.cs" />
     <Compile Include="MerchantService.cs" />
     <Compile Include="Entities\CardPoints.cs" />
     <Compile Include="Entities\Store.cs" />

--- a/OpenpayTest/ChargeServiceTest.cs
+++ b/OpenpayTest/ChargeServiceTest.cs
@@ -225,7 +225,7 @@ namespace OpenpayTest
             request.Card = GetCardInfo();
             request.Description = "Testing from .Net with new card";
             request.Amount = new Decimal(9.99);
-            request.UseCardPoints = true;
+            request.UseCardPoints = true.ToString();
 
             Customer customer = new Customer();
             customer.Name = "Openpay";
@@ -258,7 +258,7 @@ namespace OpenpayTest
             request.Card = GetCardInfo();
             request.Description = "Testing from .Net with new card";
             request.Amount = new Decimal(29.99);
-            request.UseCardPoints = true;
+            request.UseCardPoints = true.ToString();
 
             Customer customer = new Customer();
             customer.Name = "Openpay";


### PR DESCRIPTION
Fixing broken build where TransactionStatus.cs was missing from the csproj file and ChangeServiceTests had errors in use of **.UseCardPoints where string was expected and bool was supplied.